### PR TITLE
fix useWidget compatibility with generated widget constructors

### DIFF
--- a/.changeset/friendly-hounds-flow.md
+++ b/.changeset/friendly-hounds-flow.md
@@ -1,0 +1,5 @@
+---
+"@tmelliott/react-rserve": patch
+---
+
+Widen `useWidget` constructor typing to accept generated `RserveTS` widget shapes and normalize raw capabilities metadata (`strict`, `types`, `enabled`) into a stable action-capabilities contract. This removes the need for consumer-side compatibility adapters and moves the generated-ctor compatibility MRE into the library test surface.

--- a/lib/hooks/useWidget/index.test.ts
+++ b/lib/hooks/useWidget/index.test.ts
@@ -218,4 +218,25 @@ describe("WidgetStore action capabilities", () => {
     expect(dispatchSpy).toHaveBeenCalledWith("UnknownAction", { value: "z" });
     warnSpy.mockRestore();
   });
+
+  it("normalizes generated-like capabilities shape", async () => {
+    const ctor = async () => ({
+      properties: { value: createProp("x") },
+      capabilities: {
+        actions: {
+          enabled: "yes",
+          types: ["SetValue", 123, null],
+          strict: "something-unexpected",
+        },
+      },
+    });
+
+    const store = new WidgetStore(ctor as any);
+    await waitUntilReady(store);
+    const snapshot = store.getSnapshot();
+
+    expect(snapshot.capabilities?.actions.enabled).toBe(false);
+    expect(snapshot.capabilities?.actions.types).toEqual(["SetValue"]);
+    expect(snapshot.capabilities?.actions.strict).toBe("off");
+  });
 });

--- a/lib/hooks/useWidget/index.ts
+++ b/lib/hooks/useWidget/index.ts
@@ -24,6 +24,14 @@ export type WidgetCapabilities = {
   };
 };
 
+type RawWidgetCapabilities = {
+  actions?: {
+    enabled?: unknown;
+    types?: unknown;
+    strict?: unknown;
+  };
+};
+
 export type WidgetActionState = WidgetCapabilities["actions"] & {
   canUndo: boolean;
   canRedo: boolean;
@@ -93,15 +101,27 @@ export type DispatchActionFn<M extends WidgetMethods> = {
 export type Widget<
   T extends Record<string, any>,
   M extends WidgetMethods = WidgetMethods,
+  C = unknown,
 > = {
   properties: {
     [K in Exclude<keyof T, "r_type" | "r_attributes">]: Expand<
       WidgetProperty<PropType<T[K]>, ResultType<T[K]>>
     >;
   };
-  children?: Record<string, unknown>;
+  children?: C;
   methods?: M;
   capabilities?: WidgetCapabilities;
+};
+
+type WidgetCtorResult<
+  T extends Record<string, any>,
+  M extends WidgetMethods = WidgetMethods,
+  C = unknown,
+> = {
+  properties: T;
+  children?: C;
+  methods?: M;
+  capabilities?: RawWidgetCapabilities | WidgetCapabilities | unknown;
 };
 
 type WidgetState<P extends Record<string, any>> = Expand<{
@@ -112,11 +132,12 @@ type WidgetState<P extends Record<string, any>> = Expand<{
 type UseWidgetSnapshot<
   P extends Record<string, any>,
   M extends WidgetMethods = WidgetMethods,
+  C = unknown,
 > = {
-  widget: Widget<P, M> | undefined;
+  widget: Widget<P, M, C> | undefined;
   status: WidgetStatus;
-  fields: Widget<P, M>["properties"] | undefined;
-  children: Widget<P, M>["children"] | undefined;
+  fields: Widget<P, M, C>["properties"] | undefined;
+  children: Widget<P, M, C>["children"] | undefined;
   methods: M | undefined;
   capabilities: WidgetCapabilities | undefined;
   actionState: WidgetActionState | undefined;
@@ -126,7 +147,8 @@ type UseWidgetSnapshot<
 export type UseWidgetReturn<
   P extends Record<string, any>,
   M extends WidgetMethods = WidgetMethods,
-> = UseWidgetSnapshot<P, M> & {
+  C = unknown,
+> = UseWidgetSnapshot<P, M, C> & {
   set: <K extends Exclude<keyof P, "r_type" | "r_attributes">>(
     prop: K,
     value: ResultType<P[K]>,
@@ -160,19 +182,45 @@ function invokeWidgetMethod(
   return undefined;
 }
 
+function normalizeCapabilities(raw: unknown): WidgetCapabilities | undefined {
+  if (typeof raw !== "object" || raw === null) {
+    return undefined;
+  }
+  const actions = (raw as RawWidgetCapabilities).actions;
+  if (typeof actions !== "object" || actions === null) {
+    return undefined;
+  }
+
+  const strictRaw = String(actions.strict ?? "off");
+  const strict: ActionStrictness =
+    strictRaw === "warn" || strictRaw === "strict" ? strictRaw : "off";
+  const types = Array.isArray(actions.types)
+    ? actions.types.filter((x): x is string => typeof x === "string")
+    : [];
+
+  return {
+    actions: {
+      enabled: typeof actions.enabled === "boolean" ? actions.enabled : false,
+      types,
+      strict,
+    },
+  };
+}
+
 export class WidgetStore<
   T extends Record<string, any>,
   M extends WidgetMethods = WidgetMethods,
+  C = unknown,
 > {
-  private widget: Widget<T, M> | undefined;
+  private widget: Widget<T, M, C> | undefined;
   private ctor: (
     f: (
       v: Partial<Expand<WidgetState<T>>>,
       k: (err: string | null, res: null) => void
     ) => void
-  ) => Promise<Widget<T, M>>;
+  ) => Promise<WidgetCtorResult<T, M, C>>;
   private status: WidgetStatus = "loading";
-  private fields: Widget<T, M>["properties"] | undefined;
+  private fields: Widget<T, M, C>["properties"] | undefined;
   private methods: M | undefined;
   private capabilities: WidgetCapabilities | undefined;
   private actionState: WidgetActionState | undefined;
@@ -184,10 +232,10 @@ export class WidgetStore<
   private listeners = new Set<() => void>();
 
   private snapshot: {
-    widget: Widget<T, M> | undefined;
+    widget: Widget<T, M, C> | undefined;
     status: WidgetStatus;
-    fields: Widget<T>["properties"] | undefined;
-    children: Widget<T>["children"] | undefined;
+    fields: Widget<T, M, C>["properties"] | undefined;
+    children: Widget<T, M, C>["children"] | undefined;
     methods: M | undefined;
     capabilities: WidgetCapabilities | undefined;
     actionState: WidgetActionState | undefined;
@@ -200,7 +248,7 @@ export class WidgetStore<
         v: Partial<Expand<WidgetState<T>>>,
         k: (err: string | null, res: null) => void
       ) => void
-    ) => Promise<Widget<T, M>>
+    ) => Promise<WidgetCtorResult<T, M, C>>
   ) {
     this.ctor = ctor;
     this.timeoutRefs = {};
@@ -230,11 +278,15 @@ export class WidgetStore<
       this.updateState(v as any);
       k(null, null);
     });
-    this.widget = widget;
+    const capabilities = normalizeCapabilities(widget.capabilities);
+    this.widget = {
+      ...widget,
+      capabilities,
+    };
     this.fields = widget.properties;
     this.methods = widget.methods;
-    this.capabilities = widget.capabilities;
-    this.actionState = this.toActionState(widget.capabilities);
+    this.capabilities = capabilities;
+    this.actionState = this.toActionState(capabilities);
     this.status = "ready";
 
     this.updateSnapshot();
@@ -391,6 +443,7 @@ export class WidgetStore<
 export function useWidget<
   P extends Record<string, any>,
   M extends WidgetMethods = WidgetMethods,
+  C = unknown,
 >(
   ctor: (
     f: (
@@ -399,18 +452,18 @@ export function useWidget<
     ) => void
   ) => Promise<{
     properties: P;
-    children?: Record<string, unknown>;
+    children?: C;
     methods?: M;
-    capabilities?: WidgetCapabilities;
+    capabilities?: RawWidgetCapabilities | WidgetCapabilities | unknown;
   }>
-): UseWidgetReturn<P, M> {
-  const storeRef = useRef<WidgetStore<P, M>>(undefined);
+): UseWidgetReturn<P, M, C> {
+  const storeRef = useRef<WidgetStore<P, M, C>>(undefined);
 
   if (!storeRef.current) {
     storeRef.current = new WidgetStore(ctor);
   }
 
-  const state: UseWidgetSnapshot<P, M> = useSyncExternalStore(
+  const state: UseWidgetSnapshot<P, M, C> = useSyncExternalStore(
     storeRef.current.subscribe,
     storeRef.current.getSnapshot,
     storeRef.current.getSnapshot

--- a/lib/hooks/useWidget/mre/README.md
+++ b/lib/hooks/useWidget/mre/README.md
@@ -1,0 +1,22 @@
+# `useWidget` Generated Ctor Compatibility MRE
+
+This MRE documents and enforces compatibility between:
+
+- constructors generated from `RserveTS::ts_compile()` style schemas, and
+- the ctor type accepted by `useWidget()` in `@tmelliott/react-rserve`.
+
+## Why this is here
+
+This is a library contract test. Consumer apps should not need compatibility
+adapters for generated widget constructors.
+
+## Validation
+
+Run:
+
+```bash
+bun run test:types
+```
+
+The companion `repro.ts` file is compiled as part of the library typecheck and
+must compile without `@ts-expect-error`.

--- a/lib/hooks/useWidget/mre/repro.ts
+++ b/lib/hooks/useWidget/mre/repro.ts
@@ -1,0 +1,51 @@
+import { useWidget } from "../index";
+
+type GeneratedLikeWidgetCtor = (
+  f: (
+    v: Partial<{ name: string }>,
+    k: (err: string | null, res: null) => void
+  ) => void
+) => Promise<{
+  properties: {
+    name: {
+      get: () => Promise<string>;
+      set: (x: string) => Promise<void>;
+      register: (
+        cb: (v: string, k: (err: string | null, res: null) => void) => void,
+        id: string
+      ) => Promise<string>;
+    };
+  };
+  children:
+    | (unknown[] & { r_type: "vector"; r_attributes: Record<string, unknown> })
+    | (Record<string, unknown> & {
+        r_type: "vector";
+        r_attributes: { names: string[] } & Record<string, unknown>;
+      });
+  capabilities: {
+    actions: {
+      enabled: boolean;
+      types: string[];
+      strict: string;
+    };
+  };
+  methods: {
+    dispatchAction: (
+      action: { type: "SetName"; payload: { name: string } }
+    ) => Promise<unknown>;
+  };
+}>;
+
+declare const generatedWidget: GeneratedLikeWidgetCtor;
+
+export function GeneratedCtorRepro() {
+  const { capabilities, dispatchAction } = useWidget(generatedWidget);
+
+  if (capabilities) {
+    void (capabilities.actions.strict satisfies "off" | "warn" | "strict");
+  }
+  void dispatchAction({ type: "SetName", payload: { name: "x" } });
+  return null;
+}
+
+void GeneratedCtorRepro;

--- a/lib/hooks/useWidget/typetest.ts
+++ b/lib/hooks/useWidget/typetest.ts
@@ -102,3 +102,44 @@ export function TypeSurfaceChecksTypePayload() {
   void dispatchAction("SetValue", { value: "x" });
   void dispatchAction({ type: "SetValue", payload: { value: "x" } });
 }
+
+type GeneratedLikeWidgetCtor = (
+  f: (
+    v: Partial<{ name: string }>,
+    k: (err: string | null, res: null) => void
+  ) => void
+) => Promise<{
+  properties: {
+    name: MockProp<string>;
+  };
+  children:
+    | (unknown[] & { r_type: "vector"; r_attributes: Record<string, unknown> })
+    | (Record<string, unknown> & {
+        r_type: "vector";
+        r_attributes: { names: string[] } & Record<string, unknown>;
+      });
+  capabilities: {
+    actions: {
+      enabled: boolean;
+      types: string[];
+      strict: string;
+    };
+  };
+  methods: {
+    dispatchAction: (
+      action: { type: "SetName"; payload: { name: string } }
+    ) => Promise<unknown>;
+  };
+}>;
+
+declare const generatedLikeWidget: GeneratedLikeWidgetCtor;
+
+export function TypeGeneratedCtorCompatibility() {
+  const { capabilities, dispatchAction } = useWidget(generatedLikeWidget);
+
+  if (capabilities) {
+    void (capabilities.actions.strict satisfies "off" | "warn" | "strict");
+  }
+
+  void dispatchAction({ type: "SetName", payload: { name: "example" } });
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
               "lib/**/*.test.ts",
               "lib/**/*.test.tsx",
               "lib/**/typetest.ts",
+              "lib/**/mre/**",
             ],
           })
           .map((file) => [


### PR DESCRIPTION
Widen useWidget's ctor contract to accept RserveTS-generated children/capabilities shapes and normalize capabilities to a stable action contract, so consumers no longer need local compat adapters. Add library-owned MRE/type coverage and exclude MRE fixtures from build outputs.

Made-with: Cursor