### PR TITLE
fix(build): externalize rserve-ts and zod in library bundle

### DIFF
--- a/.changeset/externalize-rserve-ts.md
+++ b/.changeset/externalize-rserve-ts.md
@@ -1,0 +1,5 @@
+---
+"@tmelliott/react-rserve": patch
+---
+
+Stop bundling `rserve-ts` and `zod` in the library build (Vite `external`). Bump minimum `rserve-ts` to `0.9.3` so list `r_attributes.names` accepts arrays from R.

--- a/bun.lock
+++ b/bun.lock
@@ -4,8 +4,8 @@
     "": {
       "name": "@tmelliott/react-rserve",
       "dependencies": {
-        "rserve-ts": "0.9.1",
-        "zod": "^3.25.67",
+        "rserve-ts": "^0.9.3",
+        "zod": "^3.25.64",
       },
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.17.4",
@@ -33,6 +33,8 @@
       "peerDependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "rserve-ts": "^0.9.3",
+        "zod": "^3.25.64",
       },
     },
   },
@@ -929,7 +931,7 @@
 
     "rollup": ["rollup@4.52.5", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.52.5", "@rollup/rollup-android-arm64": "4.52.5", "@rollup/rollup-darwin-arm64": "4.52.5", "@rollup/rollup-darwin-x64": "4.52.5", "@rollup/rollup-freebsd-arm64": "4.52.5", "@rollup/rollup-freebsd-x64": "4.52.5", "@rollup/rollup-linux-arm-gnueabihf": "4.52.5", "@rollup/rollup-linux-arm-musleabihf": "4.52.5", "@rollup/rollup-linux-arm64-gnu": "4.52.5", "@rollup/rollup-linux-arm64-musl": "4.52.5", "@rollup/rollup-linux-loong64-gnu": "4.52.5", "@rollup/rollup-linux-ppc64-gnu": "4.52.5", "@rollup/rollup-linux-riscv64-gnu": "4.52.5", "@rollup/rollup-linux-riscv64-musl": "4.52.5", "@rollup/rollup-linux-s390x-gnu": "4.52.5", "@rollup/rollup-linux-x64-gnu": "4.52.5", "@rollup/rollup-linux-x64-musl": "4.52.5", "@rollup/rollup-openharmony-arm64": "4.52.5", "@rollup/rollup-win32-arm64-msvc": "4.52.5", "@rollup/rollup-win32-ia32-msvc": "4.52.5", "@rollup/rollup-win32-x64-gnu": "4.52.5", "@rollup/rollup-win32-x64-msvc": "4.52.5", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw=="],
 
-    "rserve-ts": ["rserve-ts@0.9.1", "", { "dependencies": { "underscore": "^1.13.6", "zod": "^3.25.64" } }, "sha512-XF07ssciVffrmAa+4RZ+jaqq9RxkO8dDxVLjcweXYEvO9ktxnz8CrRrvIVnmgN8GAnd2wGCgW5uy3PNSj4wD7A=="],
+    "rserve-ts": ["rserve-ts@0.9.3", "", { "dependencies": { "underscore": "^1.13.6", "zod": "^3.25.64" } }, "sha512-S3O20SSnbJ7u7uT8r12ycNjhH8kKqTnxE92fPEtyBWnCk/oghQBqY72LNWbgpRBi+B+uv1BEfN0KyEEZq8CuuA=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tmelliott/react-rserve",
   "private": false,
-  "version": "0.9.5",
+  "version": "0.10.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/tmelliott/react-rserve"
@@ -40,7 +40,9 @@
   },
   "peerDependencies": {
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "rserve-ts": "^0.9.3",
+    "zod": "^3.25.64"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
@@ -66,8 +68,8 @@
     "vitest": "^4.1.0"
   },
   "dependencies": {
-    "rserve-ts": "0.9.1",
-    "zod": "^3.25.67"
+    "rserve-ts": "^0.9.3",
+    "zod": "^3.25.64"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,7 +29,12 @@ export default defineConfig({
     },
     copyPublicDir: false,
     rollupOptions: {
-      external: ["react", "react/jsx-runtime"],
+      external: [
+        "react",
+        "react/jsx-runtime",
+        "rserve-ts",
+        "zod",
+      ],
       input: Object.fromEntries(
         glob
           .sync("lib/**/*.{ts,tsx}", {


### PR DESCRIPTION
Bundling rserve-ts 0.9.1 caused Zod validation mismatches when apps used 0.9.3 schemas (e.g. list r_attributes.names as arrays). Peer on rserve-ts and zod; bump minimum rserve-ts to 0.9.3.